### PR TITLE
4 commits to make 2 major - 2 minor changes

### DIFF
--- a/administrative/CreateSubjVar.m
+++ b/administrative/CreateSubjVar.m
@@ -148,10 +148,10 @@ elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) < length(in_fs)
         
         if in_fs(end) == 0
             trailing_empty_count = length(in_fs)-find(in_fs,1,'last'); % in several cases there are more than 1 empty channels at the end, adding only one line of NaNs wasn't enough
-            RAS_coord_tmp(end+trailing_empty_count,:) = nan;
-            MNI_coord_tmp(end+trailing_empty_count,:) = nan;
-            MGRID_coord_tmp(end+trailing_empty_count,:) = nan;
-            INF_coord_tmp(end+trailing_empty_count,:) = nan;
+            RAS_coord_tmp(end+1:end+trailing_empty_count,:) = nan;
+            MNI_coord_tmp(end+1:end+trailing_empty_count,:) = nan;
+            MGRID_coord_tmp(end+1:end+trailing_empty_count,:) = nan;
+            INF_coord_tmp(end+1:end+trailing_empty_count,:) = nan;
         else
         end
         

--- a/administrative/CreateSubjVar.m
+++ b/administrative/CreateSubjVar.m
@@ -32,15 +32,16 @@ cortex = getcort(dirs);
 [MNI_coord, chanInfo, RAS_coord] = sub2AvgBrainCustom([],dirs, sbj_name, dirs.fsDir_local);
 [MGRID_coord, elect_names] = getmgrid(dirs);
 
-
+% get inflated brain coordinates
+INF_coord = pial2InfBrain_custom(dirs);
 
 fs_chan_names = chanInfo.Name;
 close all
-V = importVolumes(dirs);
+% V = importVolumes(dirs);
 
 subjVar.sbj_name = sbj_name;
 subjVar.cortex = cortex;
-subjVar.V = V;
+% subjVar.V = V;
 
 
 %% Correct channel name
@@ -88,6 +89,7 @@ elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) == length(in_fs)
     RAS_coord = RAS_coord(in_chan_cmp,:);
     MNI_coord = MNI_coord(in_chan_cmp,:);
     MGRID_coord = MGRID_coord(in_chan_cmp,:);
+    INF_coord = INF_coord(in_chan_cmp,:);
     % 2: More channels in EDF/TDT
 elseif sum(in_chan_cmp) == length(in_chan_cmp) && sum(in_fs) < length(in_fs)
     fs_chan_names_tmp = cell(nchan_cmp,1);
@@ -106,7 +108,10 @@ elseif sum(in_chan_cmp) == length(in_chan_cmp) && sum(in_fs) < length(in_fs)
     MGRID_coord_tmp = nan(nchan_cmp,3,1);
     MGRID_coord_tmp(in_fs,:) = MGRID_coord;
     MGRID_coord = MGRID_coord_tmp;
-
+    
+    INF_coord_tmp = nan(nchan_cmp,3,1);
+    INF_coord_tmp(in_fs,:) = INF_coord;
+    INF_coord = INF_coord_tmp;
     
     % More in
 elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) < length(in_fs)
@@ -127,6 +132,7 @@ elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) < length(in_fs)
         RAS_coord = RAS_coord(in_chan_cmp,:);
         MNI_coord = MNI_coord(in_chan_cmp,:);
         MGRID_coord =  MGRID_coord(in_chan_cmp,:);
+        INF_coord =  INF_coord(in_chan_cmp,:);
         
         % Second add the EDF/TDT which are not in FS
         fs_chan_names_tmp = cell(nchan_cmp,1);
@@ -138,11 +144,14 @@ elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) < length(in_fs)
         RAS_coord_tmp = nan(size(RAS_coord,1),size(RAS_coord,2),1);
         MNI_coord_tmp = nan(size(MNI_coord,1),size(MNI_coord,2),1);
         MGRID_coord_tmp = nan(size(MGRID_coord,1),size(MGRID_coord,2),1);
-
+        INF_coord_tmp = nan(size(INF_coord,1),size(INF_coord,2),1);
+        
         if in_fs(end) == 0
-            RAS_coord_tmp(end+1,:) = nan;
-            MNI_coord_tmp(end+1,:) = nan;
-            MGRID_coord_tmp(end+1,:) = nan;
+            trailing_empty_count = length(in_fs)-find(in_fs,1,'last'); % in several cases there are more than 1 empty channels at the end, adding only one line of NaNs wasn't enough
+            RAS_coord_tmp(end+trailing_empty_count,:) = nan;
+            MNI_coord_tmp(end+trailing_empty_count,:) = nan;
+            MGRID_coord_tmp(end+trailing_empty_count,:) = nan;
+            INF_coord_tmp(end+trailing_empty_count,:) = nan;
         else
         end
         
@@ -153,7 +162,10 @@ elseif sum(in_chan_cmp) < length(in_chan_cmp) && sum(in_fs) < length(in_fs)
         MNI_coord = MNI_coord_tmp;
         
         MGRID_coord_tmp(in_fs,:) = MGRID_coord;
-        MGRID_coord = MGRID_coord_tmp;        
+        MGRID_coord = MGRID_coord_tmp;
+        
+        INF_coord_tmp(in_fs,:) = INF_coord;
+        INF_coord = INF_coord_tmp;  
     else
         warning('channel labels not fixed, please double check PPT/FS')
         mismatch_labels = 1;
@@ -173,6 +185,7 @@ if ~exist('mismatch_labels')
     subjVar.LEPTO_coord = RAS_coord(new_order,:);
     subjVar.MNI_coord = MNI_coord(new_order,:);
     subjVar.MGRID_coord = MGRID_coord(new_order,:);
+    subjVar.INF_coord = INF_coord(new_order,:);
     
     % labels mean the corrected names
     if strcmp(data_format, 'TDT')

--- a/administrative/getmgrid.m
+++ b/administrative/getmgrid.m
@@ -5,7 +5,6 @@ subj = dir(dirs.freesurfer);
 subj = subj(end).name;
 subDir = [subDir subj];
 
-[mgrid_coord, elect_names, elecRgb] = mgrid2matlab_custom(subj,0, dirs.freesurfer);
-
+[mgrid_coord, elect_names, elecRgb,~,elecPresent] = mgrid2matlab_custom(subj,0, dirs.freesurfer);
+mgrid_coord = mgrid_coord(elecPresent==1,:);
 end
-

--- a/freesurfer/getPtdIndex_custom.m
+++ b/freesurfer/getPtdIndex_custom.m
@@ -1,0 +1,276 @@
+function PTD_idx = getPtdIndex_custom(dirs)
+% function PTD_idx = getPtdIndex(fs_subj)
+%
+% Compute Proximal Tissue Density (PTD) for each electrode as described in
+% Mercier et al., Neuroimage 2017
+%
+% PTD is an index reflecting the density of neocortical gray and white matter surrounding
+% a stereotactic electrode that has its centroid either in the neocortical gray or in the
+% white matter. It is: 
+%
+% PTD=(nGray-nWhite)/(nGray+nWhite)
+% Where nGray is the # of neocortical gray matter voxels and nWhite is the
+% number of white matter voxels in the 3x3 voxel cube centered on the contact. 
+%
+% If the contact centroid is not in white or neocortical gray matter, PTD =
+% NaN.
+%
+% Be careful when a contact is in the vicinity of subcortical structures
+% PTD is computed exclusively by taking into account surrounding neocortical
+% gray and white matter voxels; no other tissue will be taken into account (e.g.
+% Hippocampus, Amygdala...). Voxel labels are taken from the FreeSurfer
+% aparc+aseg.mgz file.
+%
+% Please note that this function belongs to the iELVis toolbox
+% and is therefore subjected to the same regulations
+% (contacts: david.m.groppe@gmail.com ; manuel.mercier@a3.epfl.ch)
+%
+% input: fs_subj - name of the patient's FreeSurfer subject folder
+%
+% output: PTD_idx structure containing 
+%           >> elec: {nx1 cell}
+%           >> location: {nx1 cell}
+%           >> offset: 2
+%           >> nb_Gpix [nx1 double]
+%           >> nb_Wpix [nx1 double]
+%           >> PTD_idx.PTD [nx1 double]
+%
+% with:
+% - elec: electrodes names
+% - location: brain region where the centroid of each electrode is localized based on freesurfer parcellation
+% - Offset: max # of voxels from contact centroid to include in PTD computation. 2 produces a 3x3 cube around
+%   each contact's center voxel. correspond to the size of the cube around each electrode used to approximate 
+%   the PTD (default = 2)
+% - nb_Gpix and nb_Wpix correspond to the number of neocortical gray or white matter voxels within a cube centered around the electrode centroid
+%   (default size = 3x3 ;centroid plus offset)
+% - PTD proximal tissue density of white and neocortical gray matter around the electrode
+%
+% In addition the following files are created in the elec_recon subfolder
+% of the patient's FreeSurfer directory:
+%   -GreyWhite_classifications.mat
+%   -GreyWhite_classifications.txt
+%
+% Function dependency:
+% - MRIread from freesurfer (https://surfer.nmr.mgh.harvard.edu/)
+%
+% Files needed:
+% - MRI from elec_recon (aparc+aseg.mgz)
+% - electrodes coordinates (*.LEPTOVOX)
+% - electrodes names (*.electrodeNames)
+% - parcellation code table (FreeSurferColorLUT.txt)
+%
+%
+% Reference:
+% Mercier, M. R., Bickel, S., Megevand, P., Groppe, D. M., Schroeder, C. E.,
+% Mehta, A. D., & Lado, F. A. (2017). Evaluation of cortical local field
+% potential diffusion in stereotactic electro-encephalography recordings:
+% A glimpse on white matter signal. NeuroImage, 147, 219-232.
+
+% Change Log:
+% 08-2017: a few other minor changes for iELVis by DG. In particular,
+% instead of using wmparc.mgz, we now use aparc+aseg.mgz.
+% 08-2017: adapted for iElvis by MrM;
+% 02-2016: created by MrM;
+%
+
+X=dir(dirs.freesurfer);
+X = X(~ismember({X.name},{'.','..', '.DS_Store'}) & horzcat(X.isdir) == 1);
+if length(X)>1
+    warning('There are more than 1 folder under server/patient_code/Freesurfer. Please select the Freesurfer for this patient.')
+    FS_folder = uigetdir;
+    [~,FS_name,~] = fileparts(FS_folder);
+else
+    FS_folder=fullfile(X.folder,X.name);  % FS location in fullfile eg.'/Volumes/neurology_jparvizi$/CHINA_C17_02/Freesurfer/C17_02'
+    FS_name = X.name;   % FS name as in under Freesurfer folder of each patients' server
+end
+
+
+% load parcellation file
+recon_folder=fullfile(FS_folder,'elec_recon');
+parc_file=fullfile(FS_folder,'mri','aparc+aseg.mgz');
+mri=MRIread(parc_file);
+
+% load electrodes name
+files=dir(fullfile(recon_folder,'*.electrodeNames'));
+n=size(files,1);
+if n==1
+    label_file=fullfile(recon_folder,files.name);
+elseif n==0
+    disp('No electrodeNames file found. Please do it manualy.');
+    [temp_file,elec_dir]=uigetfile(fullfile(recon_folder,'*.electrodeNames'),'select electrode names file');
+    label_file=fullfile(elec_dir,temp_file);
+    clear elec_dir temp_file files n
+elseif n>1
+    disp('More than one electrodeNames file found. Please do it manualy.');
+    [temp_file,elec_dir]=uigetfile(fullfile(recon_folder,'*.electrodeNames'),'select electrode names file');
+    label_file=fullfile(elec_dir,temp_file);
+    clear elec_dir temp_file files n
+end
+fid=fopen(label_file);
+tmp=textscan(fid,'%s %s %s');
+fclose(fid);
+for i=3:length(tmp{1})
+    label{i-2,1}=strcat(tmp{1}{i},'_',tmp{2}{i},'_',tmp{3}{i});
+end
+clear tmp;
+
+% load electrodes coordinate
+files=dir(fullfile(recon_folder,'*.LEPTOVOX'));
+n=size(files,1);
+if n==1
+    elec_file=fullfile(recon_folder,files.name);
+elseif n==0
+    disp('No *.LEPTOVOX file found. Please do it manualy');
+    [temp_file,elec_dir]=uigetfile(fullfile(recon_folder,'*.LEPTOVOX'),'select electrode coordinate file');
+    elec_file=fullfile(elec_dir,temp_file);
+    clear elec_dir temp_file files n
+elseif n>1
+    disp('More than one *.LEPTOVOX file found. Please choose it manualy');
+    [temp_file,elec_dir]=uigetfile(fullfile(recon_folder,'*.LEPTOVOX'),'select electrode coordinate file');
+    elec_file=fullfile(elec_dir,temp_file);
+    clear elec_dir temp_file files n
+end
+fid=fopen(elec_file);
+tmp=textscan(fid,'%s %s %s');
+fclose(fid);
+for i=3:length(tmp{1})
+    elec(i-2,1)=str2num(tmp{1}{i});
+    elec(i-2,2)=str2num(tmp{2}{i});
+    elec(i-2,3)=str2num(tmp{3}{i});
+end
+clear tmp;
+elec=elec+1; % Voxel indexing starts at 0 but MATLAB indexing starts with 1
+
+%% load look-up table for the FreeSurfer MRI atlases
+FS_color_file = which('FreeSurferColorLUTnoFormat.txt');
+if isempty(FS_color_file)
+    disp('The freesurfer color code file, FreeSurferColorLUTnoFormat.txt, was not found. Please select it manualy.');
+    [temp_file,elec_dir]=uigetfile(fullfile(recon_folder,'*.txt'),'Select freesurfer color code file');
+    FS_color_file=fullfile(elec_dir,temp_file);
+    clear elec_dir temp_file
+else
+    fprintf('Loading file %s\n',FS_color_file);
+end
+
+fid=fopen(FS_color_file);
+C=textscan(fid,'%d %s %d %d %d %d');
+fclose(fid);
+
+region_lookup=C{:,2};
+region_codes=C{:,1};
+clear fid C p
+
+%% find the proportion of neocortical grey and white matter surrounding the electrodes
+sVol=size(mri.vol);
+offset = 2;
+for e=1:size(elec,1)
+%     disp(['Finding amount of surrounding grey and white matter for channel ' label{e}]);
+    x=round(elec(e,2)); % switches x and y axes to match FreeSurfer
+    y=round(elec(e,1)); % switches x and y axes to match FreeSurfer
+    z=round(sVol(3)-elec(e,3)); %need to flip direction of last coordinate
+    
+    % DG Code for double checking electrode coordinates
+    if e==0, %68, 61
+        mri_mn=min(min(min(mri.vol)));
+        mri_mx=max(max(max(mri.vol)));
+        
+        figure(2)
+        colormap('gray');
+        clf;
+        subplot(1,3,1);
+        imagesc(squeeze(mri.vol(:,y,:)),[mri_mn, mri_mx]);
+        hold on;
+        axis square;
+        set(gca,'xdir','reverse');
+        plot(z,x,'g.');
+        
+        subplot(1,3,2);
+        imagesc(squeeze(mri.vol(x,:,:)),[mri_mn, mri_mx]);
+        hold on;
+        axis square;
+        set(gca,'xdir','reverse');
+        plot(z,y,'g.');
+        
+        subplot(1,3,3);
+        imagesc(squeeze(mri.vol(:,:,z)),[mri_mn, mri_mx]);
+        hold on;
+        axis square;
+        plot(y,x,'g.');
+        
+        disp('Done.');
+    end
+    
+    % original labelling from parcellation
+    ROI(e,1) =region_lookup(region_codes==mri.vol(x,y,z));
+    
+    % check that the contact is in gray or white matter
+    gray_white=[strfind(lower(ROI{e,1}),'ctx') strfind(lower(ROI{e,1}),'cortex') ...
+        strfind(lower(ROI{e,1}),'wm') strfind(lower(ROI{e,1}),'white')];
+    if ~isempty(gray_white),
+        % get the euclidean distances between the electrode and every voxel
+        % in the MRI (this could be speed up a lot)
+        for i=1:mri.volsize(1)
+            for j=1:mri.volsize(2)
+                for k=1:mri.volsize(3)
+                    distances(i,j,k)=sqrt((i-x)^2+(j-y)^2+(k-z)^2); % could be replaced by ~ norm([i j k] - [x y z])
+                end
+            end
+        end
+        
+        % do not include the offset
+        tmp=mri.vol(distances<offset);
+        % find the regions
+        tmp_region ={};
+        for i = 1:length(tmp)
+            tmp_region(i,1) =region_lookup(region_codes==tmp(i));
+        end
+        % find gray matter voxel in the vicinity
+%         gm_nb = length(cell2mat(strfind(lower(tmp_region),'ctx')));
+%         gm_nb = gm_nb + length(cell2mat(strfind(lower(tmp_region),'cortex')));
+%         gm_w = gm_nb;
+        gm_w = sum(contains(lower(tmp_region),{'ctx','amygdala','hippocamp','thalamus','insula','operculum'}));
+        % find white matter voxel in the vicinity
+        wm_nb = length(cell2mat(strfind(lower(tmp_region),'wm')));
+        wm_nb = wm_nb + length(cell2mat(strfind(lower(tmp_region),'white')));
+        wm_w = wm_nb;
+        
+        ROI{e,2} = gm_w;
+        ROI{e,3} = wm_w;
+    else
+%         warning(['channel ' label{e} ' does not have its centroid in Neocortical Gray or White matter >> PTD=NaN']);
+        ROI{e,2} = NaN;
+        ROI{e,3} = NaN;
+    end
+end
+%% write output file
+
+for i=1:length(ROI)
+    PTD_idx.elec(i,1)     = label(i);
+    PTD_idx.location(i,1) = ROI(i,1);
+    PTD_idx.nb_Gpix(i,1)  = cell2mat(ROI(i,2));
+    PTD_idx.nb_Wpix(i,1)  = cell2mat(ROI(i,3));
+    PTD_idx.PTD (i,1)     = (cell2mat(ROI(i,2)) - cell2mat(ROI(i,3))) / (cell2mat(ROI(i,2)) + cell2mat(ROI(i,3)));
+    if (cell2mat(ROI(i,2)) + cell2mat(ROI(i,3))) ~= power(offset+1,3)
+        warning(['channel ' label{e} ' has in its surrounding voxels that are neither labelled Gray or White matter; ' char(10)...
+            'those voxels were not taking into account in PTD computation (see field nb_Gpix and nb_Wpix in the output)']);
+    end
+    % % otherwise a less strict version of the PTD taking into account the surrounding voxels that do not belong to Gray or White matter
+    %     PTD_idx.PTD (i,1)     = (cell2mat(ROI(i,2)) - cell2mat(ROI(i,3))) / power(offset+1,3);
+end
+PTD_idx.offset = offset;
+
+% % Save PTD info as mat file
+% outfile_mat=fullfile(recon_folder,'GreyWhite_classifications.mat');
+% fprintf('Writing PTD values to %s\n',outfile_mat);
+% save(outfile_mat,'PTD_idx');
+% 
+% % Raw output in txt
+% outfile=fullfile(recon_folder,'GreyWhite_classifications.txt');
+% fprintf('Writing PTD values to %s\n',outfile);
+% fid=fopen(outfile,'w');
+% fprintf(fid,'%s\t %s\t %s\t %s\r\n','Electrode','location','% Grey with offset=2','% White with offset=2');
+% for i=1:size(ROI,1)
+%     fprintf(fid,'%s\t %s\t %d\t %d\t \r\n',label{i},ROI{i,:});
+% end
+% fclose(fid);
+end

--- a/freesurfer/pial2InfBrain_custom.m
+++ b/freesurfer/pial2InfBrain_custom.m
@@ -1,0 +1,146 @@
+function infCoor=pial2InfBrain_custom(dirs)
+%function infCoor=pial2InfBrain(fsSub,cfg)
+%
+% This function takes the "pial" coordinates (snapped to pial surface) and:
+% 1. finds the closest vertex on the pial surface
+% 2. maps that vertex to the inflated brain surface
+%
+% Inputs:
+%   fsSub = FreeSurfer subject name
+%
+% Optional Inputs: passed as fields in a cfg structure
+%   elecCoord = N-by-4 numeric array with electrode RAS coordinates. The 
+%               fourth column is binary (1=Left hem elec) {default:
+%               not used; the function looks into the fsSubect's Freesurfer
+%               folder for electrode coordinate files instead}
+%   elecNames = cell array of strings with electrode names, corresponding
+%               to the rows of elecCoord. {default: not used; the function
+%               looks into the fsSubect's Freesurfer folder for electrode
+%               name file instead}
+%   fsurfsubdir = path to the Freesurfer fsSubect directory. Necessary if
+%                 running MATLAB on Windows. {default: taken from shell}
+%
+% Outputs:
+%   infCoords = Electrode coordinates on FreeSurfer inflated pial surface
+%
+%
+% Author: 
+% David Groppe
+% Mehtalab
+% April, 2013
+%
+
+% History:
+% 2015-6 Made compatible with new Yang, Wang method for brain shift correction: DG
+
+% parse input parameters in cfg structure and set defaults
+% if  ~isfield(cfg,'elecCoord'),      elecCoord = []; else    elecCoord = cfg.elecCoord;      end
+% if  ~isfield(cfg,'elecNames'),      elecNames = []; else    elecNames = cfg.elecNames;      end
+% if  ~isfield(cfg,'fsurfsubdir'),    fs_dir = [];    else    fs_dir = cfg.fsurfsubdir;       end
+%if  ~isfield(cfg,'elecHem'),        elecHem = [];   else    elecHem = cfg.elecNames;      end
+
+% Get location of FreeSurfer directories
+% if isempty(fs_dir)
+%     fs_dir=getFsurfSubDir();
+% end
+% sub_dir=fullfile(fs_dir,fsSub);
+
+fs_dir = dirs.freesurfer;
+subj = dir(fs_dir);
+subj=subj(~ismember({subj.name},{'.','..', '.DS_Store'}) & horzcat(subj.isdir) == 1);
+fsSub = subj.name;
+sub_dir = fullfile(fs_dir, fsSub);
+
+elecCoord = [];
+%% get electrode coordinates
+if isempty(elecCoord) % no electrode coordinates have been passed in the function call:
+    % use the original code looking for .PIAL files
+    %pialFname=[fs_dir '/' fsSub '/elec_recon/' fsSub '.PIAL'];
+    pialFname=fullfile(fs_dir,fsSub,'elec_recon',[fsSub '.PIAL']);
+    elecCoordCsv=csv2Cell(pialFname,' ',2);
+    nChan=size(elecCoordCsv,1);
+    RAS_coor=zeros(nChan,3);
+    for csvLoopA=1:nChan,
+        for csvLoopB=1:3,
+            RAS_coor(csvLoopA,csvLoopB)=str2num(elecCoordCsv{csvLoopA,csvLoopB});
+        end
+    end
+    %elecInfoFname=[fs_dir '/' fsSub '/elec_recon/' fsSub '.electrodeNames'];
+    elecInfoFname=fullfile(fs_dir,fsSub,'elec_recon',[fsSub '.electrodeNames']);
+    elecInfo=csv2Cell(elecInfoFname,' ',2);
+    %labels=elecInfo(:,1);
+    leftIds=find(cellfun(@(x) strcmpi(x,'L'),elecInfo(:,3)));
+    rightIds=find(cellfun(@(x) strcmpi(x,'R'),elecInfo(:,3)));
+else % numeric electrode coordinates have been passed in the function call
+    RAS_coor=elecCoord(:,1:3);
+    leftIds=find(elecCoord(:,4));
+    rightIds=find(~elecCoord(:,4));
+    nChan=size(elecCoord,1);
+    %     leftIds=find(cellfun(@(x) strcmpi(x,'L'),elecHem));
+    %     rightIds=find(cellfun(@(x) strcmpi(x,'R'),elecHem));
+    %labels=elecNames;
+    elecInfo=[];
+end
+
+
+%% Loop over hemispheres
+infCoor=zeros(nChan,3);
+for hemLoop=1:2,
+    if hemLoop==1,
+        hem='l';
+        useIds=leftIds;
+    else
+        hem='r';
+        useIds=rightIds;
+    end
+    if size(useIds,1)>1,
+        useIds=useIds';
+    end
+    
+    %% Read Sub Pial Surf
+    %fname=[sub_dir '/surf/' hem 'h.pial'];
+    fname=fullfile(sub_dir,'surf',[hem 'h.pial']);
+    pial=readSurfHelper(fname);
+    
+    %% Read Sub Inflated Surf
+    %fname=[sub_dir '/surf/' hem 'h.inflated'];
+    fname=fullfile(sub_dir,'surf',[hem 'h.inflated']);
+    inflated=readSurfHelper(fname);
+    
+    %% Get vertices for electrodes on sub's pial surface
+    nPialVert=size(pial.vert,1);
+    nUseId=length(useIds);
+    if nUseId
+        for a=useIds,
+            df=pial.vert-repmat(RAS_coor(a,:),nPialVert,1);
+            dst=sum(abs(df),2);
+            [dummy, sub_vid]=min(dst);
+            
+            %% Get electrode coordinates on inflated brain
+            infCoor(a,:)=inflated.vert(sub_vid,:);
+        end
+        
+        %% Plot to check
+        if 0
+            figure(10); clf;
+            subplot(121);
+            plot3(inflated.vert(:,1),inflated.vert(:,2),inflated.vert(:,3),'b.'); hold on;
+            plot3(infCoor(useIds,1),infCoor(useIds,2),infCoor(useIds,3),'ro');
+            axis square;
+            
+            subplot(122);
+            plot3(pial.vert(:,1),pial.vert(:,2),pial.vert(:,3),'b.'); hold on;
+            plot3(RAS_coor(useIds,1),RAS_coor(useIds,2),RAS_coor(useIds,3),'ro');
+            axis square;
+        end
+    end
+end
+
+%% Set depth coordinates to NaNs if coordinates read from file
+% if ~isempty(elecInfo),
+%     for a=1:size(elecInfo,1),
+%        if strcmpi(elecInfo{a,2},'D')
+%           infCoor(a,:)=NaN; 
+%        end
+%     end
+% end


### PR DESCRIPTION
2 major changes:
1. Inflated brain coordinates are added to subjVar elecInfo table: In CreateSubjVar, there is a function (freesurfer/pial2InfBrain_custom.m) that adds the Inflated brain coordinates to subjVar. This will make it easy to get Inflated brain coordinates of the electrodes. 
2.  Depth electrodes are now given surface label based on how many GM voxel in their surrounding: before this we were snapping the depth electrodes which have the "cortex" label from freesurfer parcellation. However some electrodes, despite having "white matter" label have significant activations. So their activity is coming from surrounding gray matter. To choose electrodes to snap to surface, method chosen here is to calculate how many cortex voxels in the vicinity and snap those electrodes which have at least 1 cortex voxel around. This method is applied in iELVis as PTD index based on Mercier et al. 2017, Neuroimage. 

2 minor changes:
1. We had discussed several cases creating problem due to their mgrids having extra channels. To overcome this problem, one line is added to getmgrid.m so that the electrodes that were physically present are given as output.
2. solution for trailing empty channels: there are several cases that there are more than 1 empty channels at the end of the chan_names. The solution was to add only 1 more line in coordinate matrices, so it was not enough in some cases. Currently, changes add "trailing_empty_count" NaNs to the end of coordinate tables.